### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,4 +1,5 @@
 import unittest
+from urllib.parse import urlparse
 
 from utils.urls import rewrite_twitter_urls, is_tiktok_url, is_instagram_url, validate_tiktok_url, validate_instagram_url
 
@@ -8,7 +9,7 @@ class UrlTests(unittest.TestCase):
         text = "check https://twitter.com/a/status/1 and https://mobile.x.com/b/status/2"
         result = rewrite_twitter_urls(text)
         self.assertEqual(len(result.rewritten_urls), 2)
-        self.assertTrue(all("vxtwitter.com" in url for url in result.rewritten_urls))
+        self.assertTrue(all(urlparse(url).hostname == "vxtwitter.com" for url in result.rewritten_urls))
 
     def test_spoiler_link(self):
         text = "||https://x.com/a/status/1||"


### PR DESCRIPTION
Potential fix for [https://github.com/stef1949/Embedly/security/code-scanning/1](https://github.com/stef1949/Embedly/security/code-scanning/1)

To fix this, parse each rewritten URL and assert against its hostname rather than searching for a substring in the whole URL.

Best single fix (without changing intended functionality):
- In `tests/test_urls.py`, import `urlparse` from `urllib.parse`.
- Replace line 11’s substring assertion with a host equality assertion:
  - Parse each URL via `urlparse(url).hostname`
  - Assert host equals `vxtwitter.com` (or, if needed, acceptable explicit variants)

This keeps the test intent (“rewritten URLs point to vxtwitter”) while removing the incomplete substring sanitization pattern.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
